### PR TITLE
`OptionGroupFormFieldFactory`: Convert boolean to option value

### DIFF
--- a/Civi/RemoteEventFormEditor/RegistrationProfile/Form/FieldFactory/DefaultFormFieldFactory.php
+++ b/Civi/RemoteEventFormEditor/RegistrationProfile/Form/FieldFactory/DefaultFormFieldFactory.php
@@ -62,9 +62,7 @@ final class DefaultFormFieldFactory implements ConcreteProfileFormFieldFactoryIn
         'validation' => $this->getValidation($editorField, $editorFieldType),
         'value' => $editorField['value'] ?? NULL,
         'parent' => $parent,
-        'dependencies' => is_array($editorField['dependencies'] ?? NULL)
-        ? DependentFieldNameUtil::toProfileFormFieldNames($editorField['dependencies'])
-        : [],
+        'dependencies' => DependentFieldNameUtil::getDependentProfileFormFieldNames($editorField),
       ],
     ];
   }

--- a/Civi/RemoteEventFormEditor/RegistrationProfile/Form/Util/DependentFieldNameUtil.php
+++ b/Civi/RemoteEventFormEditor/RegistrationProfile/Form/Util/DependentFieldNameUtil.php
@@ -22,6 +22,25 @@ namespace Civi\RemoteEventFormEditor\RegistrationProfile\Form\Util;
 final class DependentFieldNameUtil {
 
   /**
+   * Converts the dependent field names of the editor field to the names used in
+   * the profile form. If the field has no dependencies an empty array is
+   * returned.
+   *
+   * @phpstan-param array<string, mixed> $editorField
+   *
+   * @phpstan-return array<array<string, mixed>>
+   *
+   * @see toProfileFormFieldNames()
+   */
+  public static function getDependentProfileFormFieldNames(array $editorField): array {
+    if (!is_array($editorField['dependencies'] ?? NULL)) {
+      return [];
+    }
+
+    return self::toProfileFormFieldNames($editorField['dependencies']);
+  }
+
+  /**
    * Converts the dependent field names to the names used in the profile form.
    *
    * @phpstan-param array<array<string, mixed>> $dependencies


### PR DESCRIPTION
CiviCRM uses "0" and "1" as options for boolean fields, so we do need value conversion.

Additionally minor refactoring to reduce cyclomatic complexity.

systopia-reference: 24954